### PR TITLE
Fix code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -1799,4 +1799,5 @@ def get_messages():
     
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=3001, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=3001, debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/gdthrhfhrthjyr/My-website/security/code-scanning/2](https://github.com/gdthrhfhrthjyr/My-website/security/code-scanning/2)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Ensure that the environment variable is set appropriately in the deployment environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
